### PR TITLE
Add badges to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Bean Counter
 
+![GitHub package.json version](https://img.shields.io/github/package-json/v/genebean/bean-counter)
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=genebean/bean-counter)](https://dependabot.com)
+![Snyk Vulnerabilities for GitHub Repo](https://img.shields.io/snyk/vulnerabilities/github/genebean/bean-counter)
+[![Build Status](https://travis-ci.com/genebean/bean-counter.svg?branch=master)](https://travis-ci.com/genebean/bean-counter)
+![GitHub](https://img.shields.io/github/license/genebean/bean-counter)
+
 ## Dev
 
 - `npm install`


### PR DESCRIPTION
Badges added for:
- package.json version
- Dependabot
- Sync vulnerability scan status
- Travis-CI build status
- license per LICENSE file

The license one will start working once we merge in #15 or a variant of it. Also, I just updated Travis-CI to build branches so its badge will work after the next merge.